### PR TITLE
switch to manual projection scanning instead of automatic

### DIFF
--- a/OpenFTTH.EventSourcing.Tests/DependencyInjection/DependencyInjectionTests.cs
+++ b/OpenFTTH.EventSourcing.Tests/DependencyInjection/DependencyInjectionTests.cs
@@ -12,19 +12,23 @@ namespace OpenFTTH.EventSourcing.Tests
         private IServiceProvider _serviceProvider;
         private IEventStore _eventStore;
 
-        public DependencyInjectionTests(IServiceProvider serviceProvider, IEventStore eventStore)
+        public DependencyInjectionTests(
+            IServiceProvider serviceProvider,
+            IEventStore eventStore)
         {
             _serviceProvider = serviceProvider;
-
             _eventStore = eventStore;
         }
 
         [Fact]
-        public void TestThatProjectionAreAutomaticallyPickedUpInIoCByEventStore()
+        public void TestRegistrationOfProjections()
         {
+            _eventStore.ScanForProjections();
 
             // Setup
-            var poopProjection = _serviceProvider.GetServices<IProjection>().First(p => p is PoopProjection) as PoopProjection;
+            var poopProjection = _serviceProvider
+                .GetServices<IProjection>()
+                .First(p => p is PoopProjection) as PoopProjection;
 
             // Act
             var snoopy = new DogAggregate(Guid.NewGuid(), "Snoopy");
@@ -32,7 +36,10 @@ namespace OpenFTTH.EventSourcing.Tests
             _eventStore.Aggregates.Store(snoopy);
 
             // Assert
-            poopProjection.PoopReport.Find(d => d.DogName == "Snoopy").PoopTotal.Should().Be(200);
+            poopProjection.PoopReport
+                .Find(d => d.DogName == "Snoopy")
+                .PoopTotal
+                .Should().Be(200);
         }
 
         [Fact]

--- a/OpenFTTH.EventSourcing/IEventStore.cs
+++ b/OpenFTTH.EventSourcing/IEventStore.cs
@@ -22,5 +22,6 @@ namespace OpenFTTH.EventSourcing
         Task<long> CatchUpAsync(CancellationToken cancellationToken = default);
         long? CurrentStreamVersion(Guid streamId);
         Task<long?> CurrentStreamVersionAsync(Guid streamId);
+        void ScanForProjections();
     }
 }

--- a/OpenFTTH.EventSourcing/IProjectionRepository.cs
+++ b/OpenFTTH.EventSourcing/IProjectionRepository.cs
@@ -4,5 +4,6 @@
     {
         void Add(IProjection projection);
         T Get<T>();
+        void ScanServiceProviderForProjections();
     }
 }

--- a/OpenFTTH.EventSourcing/InMem/InMemEventStore.cs
+++ b/OpenFTTH.EventSourcing/InMem/InMemEventStore.cs
@@ -142,5 +142,10 @@ namespace OpenFTTH.EventSourcing.InMem
             // We -1 because we start at version 0.
             return Task.FromResult((long?)_events[streamId].Count() - 1);
         }
+
+        public void ScanForProjections()
+        {
+            _projectionRepository.ScanServiceProviderForProjections();
+        }
     }
 }

--- a/OpenFTTH.EventSourcing/Postgres/PostgresEventStore.cs
+++ b/OpenFTTH.EventSourcing/Postgres/PostgresEventStore.cs
@@ -315,7 +315,7 @@ namespace OpenFTTH.EventSourcing.Postgres
 
         private long? GetNewestSequenceNumber()
         {
-            
+
             string sql = $"SELECT MAX(seq_id) FROM {_store.Options.DatabaseSchemaName}.mt_events";
             using var conn = new NpgsqlConnection(_connectionString);
             using var cmd = new NpgsqlCommand(sql, conn);
@@ -394,6 +394,11 @@ namespace OpenFTTH.EventSourcing.Postgres
             var result = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
 
             return (long?)result;
+        }
+
+        public void ScanForProjections()
+        {
+            _projectionRepository.ScanServiceProviderForProjections();
         }
     }
 }

--- a/OpenFTTH.EventSourcing/ProjectionRepository.cs
+++ b/OpenFTTH.EventSourcing/ProjectionRepository.cs
@@ -11,7 +11,6 @@ namespace OpenFTTH.EventSourcing
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly ConcurrentBag<IProjection> _projections = new ConcurrentBag<IProjection>();
-        private bool _projectionsHasBeScanned = false;
 
         public ProjectionRepository(IServiceProvider serviceProvider)
         {
@@ -28,8 +27,6 @@ namespace OpenFTTH.EventSourcing
 
         internal void ApplyEvents(IReadOnlyList<IEventEnvelope> events)
         {
-            ScanServiceProviderForProjections();
-
             foreach (var projection in _projections)
             {
                 projection.Apply(events);
@@ -38,8 +35,6 @@ namespace OpenFTTH.EventSourcing
 
         internal async Task ApplyEventsAsync(IReadOnlyList<IEventEnvelope> events)
         {
-            ScanServiceProviderForProjections();
-
             foreach (var projection in _projections)
             {
                 await projection.ApplyAsync(events).ConfigureAwait(false);
@@ -48,8 +43,6 @@ namespace OpenFTTH.EventSourcing
 
         internal void ApplyEvent(IEventEnvelope @event)
         {
-            ScanServiceProviderForProjections();
-
             foreach (var projection in _projections)
             {
                 projection.Apply(@event);
@@ -58,37 +51,39 @@ namespace OpenFTTH.EventSourcing
 
         internal async Task ApplyEventAsync(IEventEnvelope @event)
         {
-            ScanServiceProviderForProjections();
-
             foreach (var projection in _projections)
             {
                 await projection.ApplyAsync(@event).ConfigureAwait(false);
             }
         }
 
-        private void ScanServiceProviderForProjections()
+        public void ScanServiceProviderForProjections()
         {
-            if (!_projectionsHasBeScanned && _serviceProvider != null)
+            if (_serviceProvider is null)
             {
-                var projections = _serviceProvider.GetServices<IProjection>();
-
-                if (projections != null)
-                {
-                    foreach (var projection in projections)
-                    {
-                        if (!_projections.Any(existingProjection => existingProjection.GetType() == projection.GetType()))
-                            _projections.Add(projection);
-                    }
-                }
+                throw new InvalidOperationException(
+                    "Service provider is required to scan for projections.");
             }
 
-            _projectionsHasBeScanned = true;
+            var projections = _serviceProvider.GetServices<IProjection>() ??
+                throw new InvalidOperationException(
+                    $"Could not resolve any services implementing '{nameof(IProjection)}'.");
+
+            foreach (var projection in projections)
+            {
+                var containsProjection = _projections
+                    .Any(existingProjection =>
+                         existingProjection.GetType() == projection.GetType());
+
+                if (!containsProjection)
+                {
+                    _projections.Add(projection);
+                }
+            }
         }
 
         public T Get<T>()
         {
-            ScanServiceProviderForProjections();
-
             foreach (var projection in _projections)
             {
                 if (projection is T)


### PR DESCRIPTION
We decided to switch to manual projection scanning to fix a circular dependency bug, and it gives more flexibility of when to call it.