### PR TITLE
no longer loads all events, now checks if it can find stream version

### DIFF
--- a/OpenFTTH.EventSourcing/Postgres/PostgresEventStore.cs
+++ b/OpenFTTH.EventSourcing/Postgres/PostgresEventStore.cs
@@ -88,10 +88,7 @@ namespace OpenFTTH.EventSourcing.Postgres
 
         public bool CheckIfAggregateIdHasBeenUsed(Guid id)
         {
-            using var session = _store.LightweightSession();
-            var events = session.Events.FetchStream(id);
-
-            return events is not null && events.Any();
+            return CurrentStreamVersion(id) is not null;
         }
 
         public void AppendStream(Guid streamId, long expectedVersion, object[] events)


### PR DESCRIPTION
Event streams can become quite big, and loading them all into memory to check if the stream exists can therefore be very slow. Implementation has been changed to see if it can find the stream on `streamid` instead.